### PR TITLE
Revamp landing page with retro aesthetic

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,32 +1,84 @@
 import React from "react"
-import { Link } from "gatsby"
+import styled, { keyframes } from "styled-components"
 
-import { rhythm, scale } from "../utils/typography"
 import Title from "./title"
+
+const glow = keyframes`
+  0% {
+    box-shadow: 0 0 18px rgba(255, 0, 255, 0.6), 0 0 30px rgba(0, 255, 255, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 26px rgba(255, 255, 0, 0.7), 0 0 45px rgba(0, 255, 255, 0.65);
+  }
+  100% {
+    box-shadow: 0 0 18px rgba(255, 0, 255, 0.6), 0 0 30px rgba(0, 255, 255, 0.45);
+  }
+`
+
+const OuterShell = styled.div`
+  margin: 3rem auto;
+  max-width: 960px;
+  padding: 3rem 3.5rem 2.5rem;
+  border: 5px double #ff00ff;
+  background: rgba(10, 10, 10, 0.85);
+  color: var(--text-color);
+  position: relative;
+  overflow: hidden;
+  animation: ${glow} 6s ease-in-out infinite;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(rgba(255, 255, 255, 0.07) 50%, rgba(0, 0, 0, 0.05) 50%);
+    background-size: 100% 4px;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+    opacity: 0.35;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 18px;
+    border: 2px dashed rgba(0, 255, 255, 0.45);
+    pointer-events: none;
+  }
+`
+
+const Content = styled.main`
+  position: relative;
+  z-index: 1;
+`
+
+const RetroFooter = styled.footer`
+  margin-top: 2.5rem;
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #ffff00;
+  text-shadow: 0 0 6px rgba(0, 255, 255, 0.9);
+
+  a {
+    color: #00ffff;
+  }
+`
 
 const Layout = ({ location, title, children }) => {
   const rootPath = `${__PATH_PREFIX__}/`
 
   return (
-    <div
-      style={{
-        marginLeft: `auto`,
-        marginRight: `auto`,
-        maxWidth: rhythm(24),
-        padding: `${rhythm(1.5)} ${rhythm(3 / 4)}`,
-      }}
-    >
-      <Title
-        isIndexPage={location.pathname === rootPath}
-        text={title}
-      />
-      <main>{children}</main>
-      <footer>
-        © {new Date().getFullYear()}, Built with
-        {` `}
-        <a href="https://www.gatsbyjs.org">Gatsby</a>
-      </footer>
-    </div>
+    <OuterShell>
+      <Title isIndexPage={location.pathname === rootPath} text={title} />
+      <Content>{children}</Content>
+      <RetroFooter>
+        © {new Date().getFullYear()} • Powered by Gatsby & good vibes
+      </RetroFooter>
+    </OuterShell>
   )
 }
 

--- a/src/components/title.js
+++ b/src/components/title.js
@@ -1,62 +1,78 @@
-import React from 'react';
+import React from "react"
 import { Link } from "gatsby"
-import styled from 'styled-components';
+import styled, { keyframes } from "styled-components"
 import { motion } from "framer-motion"
 
+const gradientShift = keyframes`
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+`
+
 const StyledNonIndexTitle = styled.h3`
-  font-family: Montserrat, sans-serif;
-  margin-top: 0px;
-`;
+  font-family: "Press Start 2P", cursive;
+  margin-top: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-align: center;
+  color: #ffff00;
+  text-shadow: 0 0 10px #ff00ff, 0 0 12px rgba(0, 255, 255, 0.8);
+
+  a {
+    box-shadow: none;
+    color: inherit;
+    text-decoration: none;
+  }
+`
+
+const RetroTitle = styled(motion.h1)`
+  font-family: "Press Start 2P", cursive;
+  font-size: 2.65rem;
+  line-height: 3.25rem;
+  margin: 0 0 2.75rem;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  background: linear-gradient(90deg, #ffff00, #ff00ff, #00ffff, #ffff00);
+  background-size: 300% 300%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: ${gradientShift} 14s linear infinite;
+  text-shadow: 0 0 16px rgba(255, 0, 255, 0.8);
+
+  a {
+    box-shadow: none;
+    color: inherit;
+    text-decoration: none;
+  }
+`
 
 const variants = {
-  hidden: { opacity: 0, y: '-100%' },
+  hidden: { opacity: 0, y: "-100%" },
   visible: { opacity: 1, y: 0 },
 }
 
-const Title = ({isIndexPage, text}) => {
-
+const Title = ({ isIndexPage, text }) => {
   if (isIndexPage) {
     return (
-      <motion.h1
-        initial="hidden"
-        animate="visible"
-        variants={variants}
-        transition={{ duration: 1 }}
-        style={{
-          fontSize: '2.5rem',
-          lineHeight: '3.5rem',
-          marginBottom: '2.625rem',
-          marginTop: '0px'
-        }}
-      >
-        <Link
-          style={{
-            boxShadow: `none`,
-            textDecoration: `none`,
-            color: `inherit`,
-          }}
-          to={`/`}
-        >
-          {text}
-        </Link>
-      </motion.h1>
+      <RetroTitle initial="hidden" animate="visible" variants={variants} transition={{ duration: 1.2 }}>
+        <Link to={`/`}>{text}</Link>
+      </RetroTitle>
     )
   }
 
   return (
     <StyledNonIndexTitle>
-      <Link
-        style={{
-          boxShadow: `none`,
-          textDecoration: `none`,
-          color: `inherit`,
-        }}
-        to={`/`}
-      >
-        {text}
-      </Link>
+      <Link to={`/`}>{text}</Link>
     </StyledNonIndexTitle>
   )
-};
+}
 
 export default Title

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,88 +1,222 @@
 import React from "react"
-import { Link, graphql } from "gatsby"
-import styled from 'styled-components';
+import { graphql } from "gatsby"
+import styled, { css, keyframes } from "styled-components"
 
-import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { rhythm } from "../utils/typography"
 
-const StyledNav = styled.section`
-  text-align: center;
-  
-  a {
-    margin-left: 20px;
-    margin-right: 20px;
+const marquee = keyframes`
+  0% {
+    transform: translateX(100%);
   }
-`;
+  100% {
+    transform: translateX(-100%);
+  }
+`
 
-const BlogIndex = ({ data, location }) => {
+const flicker = keyframes`
+  0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% {
+    opacity: 1;
+  }
+  20%, 24%, 55% {
+    opacity: 0.35;
+  }
+`
+
+const MarqueeShell = styled.div`
+  overflow: hidden;
+  border: 3px dashed #ffff00;
+  background: rgba(0, 0, 0, 0.75);
+  padding: 0.75rem 0;
+  margin-bottom: 2rem;
+  box-shadow: 0 0 12px #00ffff inset, 0 0 20px rgba(255, 0, 255, 0.6);
+`
+
+const MarqueeText = styled.div`
+  display: inline-block;
+  white-space: nowrap;
+  animation: ${marquee} 18s linear infinite;
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #ffff00;
+  text-shadow: 0 0 8px #ff00ff;
+`
+
+const RetroPanel = styled.section`
+  position: relative;
+  background: linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.25));
+  border: 4px double #00ffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 0 25px rgba(255, 0, 255, 0.7), inset 0 0 20px rgba(0, 0, 0, 0.6);
+  color: var(--text-color);
+  text-shadow: 0 0 6px rgba(0, 255, 255, 0.9);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 10px;
+    border: 2px dotted rgba(255, 255, 0, 0.5);
+    pointer-events: none;
+  }
+`
+
+const RetroHeading = styled.h2`
+  font-family: "Press Start 2P", cursive;
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.8rem;
+  text-transform: uppercase;
+  color: #ffff00;
+  text-shadow: 0 0 10px #ff00ff, 0 0 20px rgba(0, 255, 255, 0.8);
+  animation: ${flicker} 4s infinite;
+`
+
+const RetroParagraph = styled.p`
+  font-size: 1.5rem;
+  margin: 0 auto 1.5rem;
+  max-width: 32rem;
+  line-height: 1.4;
+`
+
+const RetroList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 2rem auto;
+  max-width: 32rem;
+  font-size: 1.4rem;
+
+  li {
+    position: relative;
+    padding-left: 2.5rem;
+    margin-bottom: 1rem;
+  }
+
+  li::before {
+    content: "✶";
+    position: absolute;
+    left: 0.75rem;
+    color: #00ffff;
+    text-shadow: 0 0 8px #ff00ff;
+  }
+`
+
+const buttonStyles = css`
+  display: inline-block;
+  padding: 1.1rem 1.75rem;
+  border: 3px solid #ff00ff;
+  border-radius: 8px;
+  background: repeating-linear-gradient(135deg, rgba(255, 0, 255, 0.25) 0, rgba(255, 0, 255, 0.25) 12px, rgba(0, 255, 255, 0.25) 12px, rgba(0, 255, 255, 0.25) 24px);
+  color: #ffff00;
+  text-decoration: none;
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  box-shadow: 0 0 18px rgba(255, 0, 255, 0.8), inset 0 0 12px rgba(0, 255, 255, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus {
+    transform: translateY(-6px) rotate(-1.5deg);
+    box-shadow: 0 0 25px rgba(255, 255, 0, 0.9), inset 0 0 14px rgba(0, 255, 255, 0.8);
+    color: #ffffff;
+  }
+
+  &:active {
+    transform: translateY(2px) scale(0.98);
+  }
+`
+
+const RetroLinks = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+`
+
+const SocialLink = styled.a`
+  ${buttonStyles}
+`
+
+const RetroSticker = styled.div`
+  margin-top: 2.5rem;
+  padding: 1rem 1.5rem;
+  border: 3px dashed #00ffff;
+  background: rgba(0, 0, 0, 0.65);
+  display: inline-block;
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 0 15px rgba(0, 255, 255, 0.8);
+`
+
+const SparkleRow = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 2rem;
+  font-size: 1.5rem;
+  color: #ffff00;
+  text-shadow: 0 0 12px #ff00ff;
+`
+
+const IndexPage = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
-  const posts = data.allMarkdownRemark.edges
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO title="THE DYSLEXIC DEVELOPER" />
-      <Bio />
-      <StyledNav>
-        <a href="/about">
-          ABOUT
-        </a>
-        <a href="/projects">
-          PROJECTS
-        </a>
-      </StyledNav>
-      {posts.map(({ node }) => {
-        const title = node.frontmatter.title || node.fields.slug
-        return (
-          <article key={node.fields.slug}>
-            <header>
-              <h3
-                style={{
-                  marginBottom: rhythm(1 / 4),
-                }}
-              >
-                <Link style={{ boxShadow: `none` }} to={node.fields.slug}>
-                  {title}
-                </Link>
-              </h3>
-              <small>{node.frontmatter.date}</small>
-            </header>
-            <section>
-              <p
-                dangerouslySetInnerHTML={{
-                  __html: node.frontmatter.description || node.excerpt,
-                }}
-              />
-            </section>
-          </article>
-        )
-      })}
+      <SEO title="Welcome to the Retro Web" />
+      <MarqueeShell>
+        <MarqueeText>
+          ✨ Welcome to the official {siteTitle} cyber hub • grab a soda, power up your speakers, and enjoy the ride ✨
+        </MarqueeText>
+      </MarqueeShell>
+      <RetroPanel>
+        <RetroHeading>Hey there, I'm The Dyslexic Developer!</RetroHeading>
+        <RetroParagraph>
+          Plug in your modem and join me on a neon-soaked tour through my corner of the internet. I build playful
+          experiences, tinker with creative code, and share stories about the journey along the way.
+        </RetroParagraph>
+        <RetroList>
+          <li>Dial-up deep dives into code, art, and accessibility.</li>
+          <li>Creative experiments fueled by caffeine and curiosity.</li>
+          <li>A community-minded builder who still loves a good easter egg.</li>
+        </RetroList>
+        <RetroLinks>
+          <SocialLink href="https://twitter.com/TheDyslexicDev" target="_blank" rel="noopener noreferrer">
+            Twitter HQ
+          </SocialLink>
+          <SocialLink href="https://github.com/TheDyslexicDeveloper" target="_blank" rel="noopener noreferrer">
+            GitHub Lab
+          </SocialLink>
+          <SocialLink href="https://instagram.com/thedyslexicdeveloper" target="_blank" rel="noopener noreferrer">
+            Instagram Gallery
+          </SocialLink>
+          <SocialLink href="/about">
+            About Me
+          </SocialLink>
+        </RetroLinks>
+        <SparkleRow>
+          <span>★</span>
+          <span>Beep Boop</span>
+          <span>★</span>
+        </SparkleRow>
+        <RetroSticker>Constructed with love, pixels, and a dash of nostalgia.</RetroSticker>
+      </RetroPanel>
     </Layout>
   )
 }
 
-export default BlogIndex
+export default IndexPage
 
 export const pageQuery = graphql`
   query {
     site {
       siteMetadata {
         title
-      }
-    }
-    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
-      edges {
-        node {
-          excerpt
-          fields {
-            slug
-          }
-          frontmatter {
-            date(formatString: "MMMM DD, YYYY")
-            title
-          }
-        }
       }
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,26 +1,53 @@
-/*default styles to dark mode*/
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
+
 :root {
-    --bg-color: #000000;
-    --text-color: #f5eded;
+    --bg-color: #040013;
+    --text-color: #f8f6ff;
 }
 
-/* if the user has light change */
-@media (prefers-color-scheme: light) {
-    body {
-        --bg-color: #eee;
-        --text-color: black;
-    }
+* {
+    box-sizing: border-box;
 }
 
 body {
+    margin: 0;
+    font-family: 'VT323', 'Courier New', monospace;
+    font-size: 20px;
+    line-height: 1.6;
     background-color: var(--bg-color);
+    background-image:
+        radial-gradient(#ff00ff 1px, transparent 1px),
+        radial-gradient(#00ffff 1px, transparent 1px),
+        radial-gradient(#ffff00 1px, transparent 1px);
+    background-size: 120px 120px, 160px 160px, 200px 200px;
+    background-position: 0 0, 40px 100px, 80px 60px;
     color: var(--text-color);
+    text-shadow: 0 0 4px rgba(0, 255, 255, 0.5);
+    min-height: 100vh;
 }
 
 a {
-    color: #d65a31;
+    color: #00ffff;
+    text-decoration: underline;
+    text-decoration-style: wavy;
+    text-decoration-color: #ff00ff;
+    text-shadow: 0 0 6px rgba(255, 0, 255, 0.8);
 }
 
-h1 {
-    font-size: 3rem;
+a:hover,
+a:focus {
+    color: #ffff00;
+    text-decoration-color: #ffff00;
+}
+
+p {
+    margin-bottom: 1.25rem;
+}
+
+main {
+    min-height: 50vh;
+}
+
+img {
+    image-rendering: pixelated;
 }


### PR DESCRIPTION
## Summary
- replace the blog index with a retro-inspired welcome hub and prominent social links
- restyle the shared layout and title components with neon borders and animated gradients
- refresh global styles with pixel fonts, patterned background, and updated link treatments

## Testing
- npm install *(fails: sharp requires system dependency libvips in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efe3163690832a8c1b02f079d2361c