### PR TITLE
Redesign site with low-poly Y2K aesthetic

### DIFF
--- a/src/components/bio.js
+++ b/src/components/bio.js
@@ -8,19 +8,57 @@
 import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import Image from "gatsby-image"
-import styled from 'styled-components';
+import styled from "styled-components"
 import { motion } from "framer-motion"
 
 import { rhythm } from "../utils/typography"
 
-const StyledSocialLink = styled.a.attrs(
-  props => ({ target: props.self ? '_self' : '_blank'})
-)`
+const BioShell = styled(motion.div)`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.25rem;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 245, 255, 0.12),
+    rgba(255, 61, 242, 0.12)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  clip-path: polygon(
+    0 1rem,
+    1rem 0,
+    100% 0,
+    100% calc(100% - 1rem),
+    calc(100% - 1rem) 100%,
+    0 100%
+  );
+
+  p {
+    margin: 0;
+    color: var(--muted-text);
+  }
+
+  strong {
+    color: var(--acid);
+  }
+`
+
+const AvatarFrame = styled.div`
+  flex: 0 0 auto;
+  padding: 4px;
+  background: linear-gradient(135deg, var(--acid), var(--cyan), var(--pink));
+  clip-path: polygon(50% 0, 100% 30%, 86% 100%, 14% 100%, 0 30%);
+
+  .gatsby-image-wrapper {
+    clip-path: polygon(50% 0, 100% 30%, 86% 100%, 14% 100%, 0 30%);
+  }
+`
+
+const StyledSocialLink = styled.a`
   margin-left: 5px;
   margin-right: 5px;
-`;
-
-
+  font-weight: 700;
+`
 
 const Bio = () => {
   const data = useStaticQuery(graphql`
@@ -51,57 +89,58 @@ const Bio = () => {
   const { author, social } = data.site.siteMetadata
 
   const variants = {
-    hidden: { scale: 0.2 },
-    visible: { scale: 1 },
+    hidden: { scale: 0.9, opacity: 0 },
+    visible: { scale: 1, opacity: 1 },
   }
 
   return (
-    <motion.div
+    <BioShell
       initial="hidden"
       animate="visible"
       variants={variants}
-      transition={{ duration: 1 }}
-      style={{
-        display: `flex`
-      }}
+      transition={{ duration: 0.6 }}
     >
-      <Image
-        fixed={data.avatar.childImageSharp.fixed}
-        alt={author.name}
-        style={{
-          marginRight: rhythm(1 / 2),
-          marginBottom: 0,
-          minWidth: 50,
-          borderRadius: `100%`,
-        }}
-        imgStyle={{
-          borderRadius: `50%`,
-        }}
-      />
+      <AvatarFrame>
+        <Image
+          fixed={data.avatar.childImageSharp.fixed}
+          alt={author.name}
+          style={{
+            marginRight: rhythm(1 / 2),
+            marginBottom: 0,
+            minWidth: 50,
+          }}
+        />
+      </AvatarFrame>
       <p>
-        Opinionated rambles by <strong>{author.name}</strong> {author.summary}
-        {` `}
+        Opinionated rambles by <strong>{author.name}</strong> {author.summary}{" "}
         Follow me on
-        <StyledSocialLink href={`https://twitter.com/${social.twitter}`}>
-           Twitter
+        <StyledSocialLink
+          href={`https://twitter.com/${social.twitter}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Twitter
         </StyledSocialLink>
         ,
-        <StyledSocialLink href={`https://instagram.com/${social.instagram}`}>
-          Instagram
-        </StyledSocialLink>
-        or
-        <StyledSocialLink href={`https://github.com/${social.github}`}>
-          Github
-        </StyledSocialLink>
-         more about me
         <StyledSocialLink
-          href="/about"
-          self
+          href={`https://instagram.com/${social.instagram}`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          here
-        </StyledSocialLink>
+          Instagram
+        </StyledSocialLink>{" "}
+        or
+        <StyledSocialLink
+          href={`https://github.com/${social.github}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Github
+        </StyledSocialLink>{" "}
+        more about me
+        <StyledSocialLink href="/about">here</StyledSocialLink>
       </p>
-    </motion.div>
+    </BioShell>
   )
 }
 

--- a/src/components/inLineLink.js
+++ b/src/components/inLineLink.js
@@ -1,15 +1,16 @@
 import React from "react"
 import PropTypes from "prop-types"
-import styled from 'styled-components';
+import styled from "styled-components"
 
 const StyledLink = styled.a`
   margin-left: 3px;
   margin-right: 3px;
-`;
+  font-weight: 700;
+`
 
-const InLineLink = ({link, children}) => {
+const InLineLink = ({ link, children }) => {
   return (
-    <StyledLink href={link} target="_blank">
+    <StyledLink href={link} target="_blank" rel="noopener noreferrer">
       {children}
     </StyledLink>
   )
@@ -17,8 +18,7 @@ const InLineLink = ({link, children}) => {
 
 InLineLink.propTypes = {
   link: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
 }
 
 export default InLineLink
-

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -3,46 +3,90 @@ import styled, { keyframes } from "styled-components"
 
 import Title from "./title"
 
-const glow = keyframes`
-  0% {
-    box-shadow: 0 0 18px rgba(255, 0, 255, 0.6), 0 0 30px rgba(0, 255, 255, 0.45);
+const floatShard = keyframes`
+  0%, 100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
   }
   50% {
-    box-shadow: 0 0 26px rgba(255, 255, 0, 0.7), 0 0 45px rgba(0, 255, 255, 0.65);
+    transform: translate3d(14px, -18px, 0) rotate(8deg);
   }
-  100% {
-    box-shadow: 0 0 18px rgba(255, 0, 255, 0.6), 0 0 30px rgba(0, 255, 255, 0.45);
+`
+
+const pulseGlow = keyframes`
+  0%, 100% {
+    box-shadow: 22px 22px 0 rgba(255, 61, 242, 0.32), -18px -18px 0 rgba(0, 245, 255, 0.22), 0 28px 80px rgba(0, 0, 0, 0.48);
+  }
+  50% {
+    box-shadow: 28px 28px 0 rgba(216, 255, 0, 0.25), -24px -24px 0 rgba(255, 61, 242, 0.22), 0 34px 100px rgba(0, 245, 255, 0.2);
   }
 `
 
 const OuterShell = styled.div`
+  width: min(1080px, calc(100% - 2rem));
   margin: 3rem auto;
-  max-width: 960px;
-  padding: 3rem 3.5rem 2.5rem;
-  border: 5px double #ff00ff;
-  background: rgba(10, 10, 10, 0.85);
+  padding: clamp(1.5rem, 4vw, 3.5rem);
   color: var(--text-color);
   position: relative;
-  overflow: hidden;
-  animation: ${glow} 6s ease-in-out infinite;
+  isolation: isolate;
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.13),
+      transparent 22%
+    ),
+    linear-gradient(315deg, rgba(0, 245, 255, 0.14), transparent 28%),
+    var(--panel-color);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  clip-path: polygon(
+    0 3rem,
+    3rem 0,
+    100% 0,
+    100% calc(100% - 3rem),
+    calc(100% - 3rem) 100%,
+    0 100%
+  );
+  backdrop-filter: blur(16px);
+  animation: ${pulseGlow} 7s ease-in-out infinite;
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: linear-gradient(rgba(255, 255, 255, 0.07) 50%, rgba(0, 0, 0, 0.05) 50%);
-    background-size: 100% 4px;
-    mix-blend-mode: overlay;
-    pointer-events: none;
-    opacity: 0.35;
-  }
-
+  &::before,
   &::after {
     content: "";
     position: absolute;
-    inset: 18px;
-    border: 2px dashed rgba(0, 255, 255, 0.45);
     pointer-events: none;
+    z-index: -1;
+  }
+
+  &::before {
+    inset: 0;
+    background: linear-gradient(
+        128deg,
+        transparent 0 41%,
+        rgba(255, 255, 255, 0.16) 41% 41.3%,
+        transparent 41.3% 100%
+      ),
+      linear-gradient(
+        42deg,
+        transparent 0 63%,
+        rgba(216, 255, 0, 0.18) 63% 63.35%,
+        transparent 63.35% 100%
+      );
+    clip-path: inherit;
+  }
+
+  &::after {
+    right: -2.8rem;
+    top: 5rem;
+    width: 8.5rem;
+    height: 8.5rem;
+    background: linear-gradient(
+      135deg,
+      var(--acid),
+      var(--orange) 48%,
+      var(--pink)
+    );
+    clip-path: polygon(50% 0, 100% 34%, 78% 100%, 18% 82%, 0 24%);
+    filter: drop-shadow(0 0 24px rgba(216, 255, 0, 0.55));
+    opacity: 0.82;
+    animation: ${floatShard} 6s ease-in-out infinite;
   }
 `
 
@@ -51,20 +95,25 @@ const Content = styled.main`
   z-index: 1;
 `
 
-const RetroFooter = styled.footer`
-  margin-top: 2.5rem;
+const FooterBar = styled.footer`
+  margin-top: 3rem;
   position: relative;
   z-index: 1;
-  text-align: center;
-  font-family: "Press Start 2P", cursive;
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(0, 245, 255, 0.35);
+  color: var(--muted-text);
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #ffff00;
-  text-shadow: 0 0 6px rgba(0, 255, 255, 0.9);
 
-  a {
-    color: #00ffff;
+  span:last-child {
+    color: var(--acid);
+    font-family: "Orbitron", sans-serif;
   }
 `
 
@@ -75,9 +124,10 @@ const Layout = ({ location, title, children }) => {
     <OuterShell>
       <Title isIndexPage={location.pathname === rootPath} text={title} />
       <Content>{children}</Content>
-      <RetroFooter>
-        © {new Date().getFullYear()} • Powered by Gatsby & good vibes
-      </RetroFooter>
+      <FooterBar>
+        <span>© {new Date().getFullYear()} The Dyslexic Developer</span>
+        <span>Low-poly Y2K mode online</span>
+      </FooterBar>
     </OuterShell>
   )
 }

--- a/src/components/title.js
+++ b/src/components/title.js
@@ -3,68 +3,136 @@ import { Link } from "gatsby"
 import styled, { keyframes } from "styled-components"
 import { motion } from "framer-motion"
 
-const gradientShift = keyframes`
-  0% {
+const chromaDrift = keyframes`
+  0%, 100% {
     background-position: 0% 50%;
+    filter: hue-rotate(0deg);
   }
   50% {
     background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
+    filter: hue-rotate(32deg);
   }
 `
 
+const orbit = keyframes`
+  0%, 100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-10px) rotate(12deg);
+  }
+`
+
+const titleLinkStyles = `
+  border: 0;
+  box-shadow: none;
+  color: inherit;
+  text-decoration: none;
+`
+
 const StyledNonIndexTitle = styled.h3`
-  font-family: "Press Start 2P", cursive;
-  margin-top: 0;
-  font-size: 1.2rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  margin: 0 0 2rem;
+  font-size: clamp(1rem, 2.5vw, 1.35rem);
+  letter-spacing: 0.22em;
   text-align: center;
-  color: #ffff00;
-  text-shadow: 0 0 10px #ff00ff, 0 0 12px rgba(0, 255, 255, 0.8);
+  color: var(--acid);
+  text-shadow: 0.1em 0.1em 0 var(--pink), -0.06em -0.06em 0 var(--cyan);
 
   a {
-    box-shadow: none;
-    color: inherit;
-    text-decoration: none;
+    ${titleLinkStyles}
+  }
+`
+
+const TitleWrap = styled.div`
+  position: relative;
+  margin-bottom: 3rem;
+  perspective: 700px;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: clamp(3rem, 12vw, 8rem);
+    height: clamp(3rem, 12vw, 8rem);
+    background: linear-gradient(
+      135deg,
+      var(--cyan),
+      var(--violet),
+      var(--pink)
+    );
+    clip-path: polygon(50% 0, 100% 35%, 78% 100%, 14% 82%, 0 24%);
+    opacity: 0.72;
+    filter: drop-shadow(0 0 22px rgba(0, 245, 255, 0.55));
+    animation: ${orbit} 7s ease-in-out infinite;
+    z-index: -1;
+  }
+
+  &::before {
+    left: -1rem;
+  }
+
+  &::after {
+    right: -1rem;
+    animation-delay: -3.2s;
+    background: linear-gradient(
+      135deg,
+      var(--acid),
+      var(--orange),
+      var(--pink)
+    );
   }
 `
 
 const RetroTitle = styled(motion.h1)`
-  font-family: "Press Start 2P", cursive;
-  font-size: 2.65rem;
-  line-height: 3.25rem;
-  margin: 0 0 2.75rem;
+  position: relative;
+  margin: 0;
   text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.25em;
-  background: linear-gradient(90deg, #ffff00, #ff00ff, #00ffff, #ffff00);
-  background-size: 300% 300%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: ${gradientShift} 14s linear infinite;
-  text-shadow: 0 0 16px rgba(255, 0, 255, 0.8);
+  font-size: clamp(2.6rem, 9vw, 6.4rem);
+  line-height: 0.95;
+  letter-spacing: 0.04em;
+  transform: rotateX(12deg) rotateY(-5deg);
+  transform-style: preserve-3d;
 
   a {
-    box-shadow: none;
-    color: inherit;
-    text-decoration: none;
+    ${titleLinkStyles}
+    display: inline-block;
+    background: linear-gradient(
+      90deg,
+      var(--acid),
+      var(--cyan),
+      var(--pink),
+      var(--orange),
+      var(--acid)
+    );
+    background-size: 300% 300%;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: ${chromaDrift} 12s linear infinite;
+    text-shadow: 0.08em 0.08em 0 rgba(255, 61, 242, 0.8),
+      -0.05em -0.04em 0 rgba(0, 245, 255, 0.75),
+      0 0 32px rgba(216, 255, 0, 0.28);
   }
 `
 
 const variants = {
-  hidden: { opacity: 0, y: "-100%" },
-  visible: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: -40, rotateX: -20 },
+  visible: { opacity: 1, y: 0, rotateX: 0 },
 }
 
 const Title = ({ isIndexPage, text }) => {
   if (isIndexPage) {
     return (
-      <RetroTitle initial="hidden" animate="visible" variants={variants} transition={{ duration: 1.2 }}>
-        <Link to={`/`}>{text}</Link>
-      </RetroTitle>
+      <TitleWrap>
+        <RetroTitle
+          initial="hidden"
+          animate="visible"
+          variants={variants}
+          transition={{ duration: 1.1 }}
+        >
+          <Link to={`/`}>{text}</Link>
+        </RetroTitle>
+      </TitleWrap>
     )
   }
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,8 +1,32 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
+import styled from "styled-components"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
+
+const ErrorPanel = styled.section`
+  min-height: 22rem;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2rem;
+  background: radial-gradient(
+      circle at 50% 0,
+      rgba(255, 61, 242, 0.28),
+      transparent 14rem
+    ),
+    rgba(0, 0, 0, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  clip-path: polygon(
+    0 2rem,
+    2rem 0,
+    100% 0,
+    100% calc(100% - 2rem),
+    calc(100% - 2rem) 100%,
+    0 100%
+  );
+`
 
 const NotFoundPage = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
@@ -10,8 +34,13 @@ const NotFoundPage = ({ data, location }) => {
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="404: Not Found" />
-      <h1>Not Found</h1>
-      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      <ErrorPanel>
+        <div>
+          <h1>404</h1>
+          <p>This polygon drifted outside the mesh.</p>
+          <Link to="/">Re-enter the portal</Link>
+        </div>
+      </ErrorPanel>
     </Layout>
   )
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -2,114 +2,154 @@ import React from "react"
 import SEO from "../components/seo"
 import Layout from "../components/layout"
 import { graphql } from "gatsby"
-import styled, { css } from 'styled-components';
+import styled, { css } from "styled-components"
 import InLineLink from "../components/inLineLink"
 
 const baseHighlightStyles = css`
   font-style: italic;
-  color: #C94660;
-`;
+  color: var(--acid);
+  font-weight: 700;
+`
 
 const StyledWhoQuestion = styled.span`
-    font-size: 20px;
-    ${baseHighlightStyles}
-`;
+  font-size: 20px;
+  ${baseHighlightStyles}
+`
 
 const StyledHighLightedText = styled.span`
   ${baseHighlightStyles}
-`;
+`
 
 const StyledAboutMeSection = styled.section`
+  position: relative;
+  margin: 1.5rem 0;
+  padding: 1.4rem;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 245, 255, 0.1),
+    rgba(255, 61, 242, 0.12)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  clip-path: polygon(0 1.1rem, 1.1rem 0, 100% 0, 100% 100%, 0 100%);
+
   p {
     margin-top: 10px;
   }
-`;
+
+  &::before {
+    content: "";
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    width: 2rem;
+    height: 2rem;
+    background: linear-gradient(135deg, var(--pink), var(--cyan));
+    clip-path: polygon(50% 0, 100% 34%, 78% 100%, 14% 82%, 0 26%);
+    opacity: 0.72;
+  }
+`
 
 const StyledAboutMeSectionTitle = styled.a`
-  font-size: 3rem;
-`;
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-family: "Orbitron", sans-serif;
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  color: var(--cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`
 
 const StyledList = styled.ul`
   list-style: none;
-  
+  padding-left: 0;
+
   li {
-    padding-left: 20px;
+    position: relative;
+    padding-left: 28px;
     margin-bottom: 15px;
   }
-`;
+
+  li::before {
+    content: "◆";
+    position: absolute;
+    left: 0;
+    color: var(--pink);
+  }
+`
 
 const About = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title={data.site.siteMetadata.title} />
-      <h1>
-        About Me
-      </h1>
+      <h1>About Me</h1>
       <StyledAboutMeSection>
         <p>
-          <StyledWhoQuestion>Who is the Dyslexic Developer?</StyledWhoQuestion> a great question that one one has asked.
-          I still feel the need to explain.
+          <StyledWhoQuestion>Who is the Dyslexic Developer?</StyledWhoQuestion>{" "}
+          a great question that one one has asked. I still feel the need to
+          explain.
         </p>
         <p>
-          The Dyslexic Developer is <StyledHighLightedText>Chris Laughlin</StyledHighLightedText>, a software developer
-          from <StyledHighLightedText> Northern Ireland </StyledHighLightedText>. He started his journey in the crazy world
-          of development in 2010. Working with companies like <StyledHighLightedText> Microsoft </StyledHighLightedText>,
-          <StyledHighLightedText> Asidua </StyledHighLightedText>, and <StyledHighLightedText> Rapid7 </StyledHighLightedText>.
-          He spends way to much time on <StyledHighLightedText>Twitter </StyledHighLightedText> and <StyledHighLightedText> Github </StyledHighLightedText>
-          trying to maintain some sort of open-source presence. He has a <StyledHighLightedText>TODO </StyledHighLightedText>
-          list a mile long of things to try and learn that grows every day. Check out some of the adventures
-          he's taken below.
+          The Dyslexic Developer is{" "}
+          <StyledHighLightedText>Chris Laughlin</StyledHighLightedText>, a
+          software developer from{" "}
+          <StyledHighLightedText> Northern Ireland </StyledHighLightedText>. He
+          started his journey in the crazy world of development in 2010. Working
+          with companies like{" "}
+          <StyledHighLightedText> Microsoft </StyledHighLightedText>,
+          <StyledHighLightedText> Asidua </StyledHighLightedText>, and{" "}
+          <StyledHighLightedText> Rapid7 </StyledHighLightedText>. He spends way
+          to much time on{" "}
+          <StyledHighLightedText>Twitter </StyledHighLightedText> and{" "}
+          <StyledHighLightedText> Github </StyledHighLightedText>
+          trying to maintain some sort of open-source presence. He has a{" "}
+          <StyledHighLightedText>TODO </StyledHighLightedText>
+          list a mile long of things to try and learn that grows every day.
+          Check out some of the adventures he's taken below.
         </p>
       </StyledAboutMeSection>
-      <StyledAboutMeSection
-        id="live-streaming"
-      >
-        <StyledAboutMeSectionTitle
-          href="#live-streaming"
-        >
+      <StyledAboutMeSection id="live-streaming">
+        <StyledAboutMeSectionTitle href="#live-streaming">
           Live Streaming
         </StyledAboutMeSectionTitle>
         <p>
-          I run a weekly live stream on <StyledHighLightedText> Twitch </StyledHighLightedText>, where I try out new web
-          tech and build small projects. I always have a <StyledHighLightedText> drink  </StyledHighLightedText> at hand to
-          help me along the way. All Streams are uploaded to <StyledHighLightedText> Youtube </StyledHighLightedText> after
+          I run a weekly live stream on{" "}
+          <StyledHighLightedText> Twitch </StyledHighLightedText>, where I try
+          out new web tech and build small projects. I always have a{" "}
+          <StyledHighLightedText> drink </StyledHighLightedText> at hand to help
+          me along the way. All Streams are uploaded to{" "}
+          <StyledHighLightedText> Youtube </StyledHighLightedText> after
         </p>
         <p>
           You can subscribe to the channel
-          <InLineLink
-            link="https://www.twitch.tv/chrislaughlin"
-          >
+          <InLineLink link="https://www.twitch.tv/chrislaughlin">
             here
-          </InLineLink> and see all previous coding videos
+          </InLineLink>{" "}
+          and see all previous coding videos
         </p>
-            <p>
+        <p>
           You can see all previous coding videos
-          <InLineLink
-            link="https://www.youtube.com/channel/UCMsliAfPkd00UdKJVAOzWWw/"
-          >
+          <InLineLink link="https://www.youtube.com/channel/UCMsliAfPkd00UdKJVAOzWWw/">
             here
           </InLineLink>
         </p>
       </StyledAboutMeSection>
-      <StyledAboutMeSection
-        id="talks"
-      >
-        <StyledAboutMeSectionTitle
-          href="#talks"
-        >
+      <StyledAboutMeSection id="talks">
+        <StyledAboutMeSectionTitle href="#talks">
           Talks
         </StyledAboutMeSectionTitle>
         <p>
-          I am a regular <StyledHighLightedText> speaker </StyledHighLightedText> at local
-          <StyledHighLightedText> meetups </StyledHighLightedText> and have spoken at a number of
-          <StyledHighLightedText> conferences </StyledHighLightedText>. I have also organized and spoken at internal work
-          <StyledHighLightedText> lunch and learn </StyledHighLightedText> sessions.
+          I am a regular{" "}
+          <StyledHighLightedText> speaker </StyledHighLightedText> at local
+          <StyledHighLightedText> meetups </StyledHighLightedText> and have
+          spoken at a number of
+          <StyledHighLightedText> conferences </StyledHighLightedText>. I have
+          also organized and spoken at internal work
+          <StyledHighLightedText> lunch and learn </StyledHighLightedText>{" "}
+          sessions.
         </p>
         <p>
-          <StyledWhoQuestion>
-            Meetups:
-          </StyledWhoQuestion>
+          <StyledWhoQuestion>Meetups:</StyledWhoQuestion>
           <StyledList>
             <li>
               <InLineLink link="https://www.meetup.com/Belfast-JS/">
@@ -119,9 +159,7 @@ const About = ({ data, location }) => {
           </StyledList>
         </p>
         <p>
-          <StyledWhoQuestion>
-            Conferences:
-          </StyledWhoQuestion>
+          <StyledWhoQuestion>Conferences:</StyledWhoQuestion>
           <StyledList>
             <li>
               <InLineLink link="https://youtu.be/8GCRPffeAB8">
@@ -140,7 +178,8 @@ const About = ({ data, location }) => {
             </li>
             <li>
               <InLineLink link="https://youtu.be/g-Mb-XlteAY">
-                NI Dev Conf 2019: All your packages are belong to us - Protecting your npm dependencies
+                NI Dev Conf 2019: All your packages are belong to us -
+                Protecting your npm dependencies
               </InLineLink>
             </li>
             <li>
@@ -156,43 +195,41 @@ const About = ({ data, location }) => {
           </StyledList>
         </p>
       </StyledAboutMeSection>
-      <StyledAboutMeSection
-        id="publications"
-      >
-        <StyledAboutMeSectionTitle
-          href="#publications"
-        >
+      <StyledAboutMeSection id="publications">
+        <StyledAboutMeSectionTitle href="#publications">
           Publications
         </StyledAboutMeSectionTitle>
         <p>
-          I have been published on <StyledHighLightedText> external </StyledHighLightedText> blogs and contributed to
+          I have been published on{" "}
+          <StyledHighLightedText> external </StyledHighLightedText> blogs and
+          contributed to
           <StyledHighLightedText> books </StyledHighLightedText>
         </p>
         <p>
-          <StyledWhoQuestion>
-            Blogs:
-          </StyledWhoQuestion>
+          <StyledWhoQuestion>Blogs:</StyledWhoQuestion>
           <StyledList>
             <li>
               <InLineLink link="https://www.sitepoint.com/style-react-components-styled-components/">
-                SitePoint 2017: Styling in React: From External CSS to Styled Components
+                SitePoint 2017: Styling in React: From External CSS to Styled
+                Components
               </InLineLink>
             </li>
             <li>
               <InLineLink link="https://www.sitepoint.com/getting-started-with-codemods/">
-                SitePoint 2017: Refactor Code in Your Lunch Break: Getting Started with Codemods
+                SitePoint 2017: Refactor Code in Your Lunch Break: Getting
+                Started with Codemods
               </InLineLink>
             </li>
           </StyledList>
         </p>
         <p>
-          <StyledWhoQuestion>
-            Books:
-          </StyledWhoQuestion>
+          <StyledWhoQuestion>Books:</StyledWhoQuestion>
           <StyledList>
             <li>
               <InLineLink link="https://www.amazon.com/Understanding-Internet-Applications-Information-Professional/dp/1843344998">
-                Chandos Publishing 2009: Understanding the Internet: A Glimpse into the Building Blocks, Applications, Security and Hidden Secrets of the Web
+                Chandos Publishing 2009: Understanding the Internet: A Glimpse
+                into the Building Blocks, Applications, Security and Hidden
+                Secrets of the Web
               </InLineLink>
             </li>
           </StyledList>
@@ -205,11 +242,11 @@ const About = ({ data, location }) => {
 export default About
 
 export const pageQuery = graphql`
-    query {
-        site {
-            siteMetadata {
-                title
-            }
-        }
+  query {
+    site {
+      siteMetadata {
+        title
+      }
     }
+  }
 `

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,162 +5,238 @@ import styled, { css, keyframes } from "styled-components"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-const marquee = keyframes`
+const scanner = keyframes`
   0% {
-    transform: translateX(100%);
+    transform: translateX(-100%);
   }
   100% {
-    transform: translateX(-100%);
+    transform: translateX(100%);
   }
 `
 
-const flicker = keyframes`
-  0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% {
-    opacity: 1;
+const hoverShard = keyframes`
+  0%, 100% {
+    transform: translateY(0) rotate(0deg);
   }
-  20%, 24%, 55% {
-    opacity: 0.35;
+  50% {
+    transform: translateY(-14px) rotate(9deg);
   }
 `
 
 const MarqueeShell = styled.div`
-  overflow: hidden;
-  border: 3px dashed #ffff00;
-  background: rgba(0, 0, 0, 0.75);
-  padding: 0.75rem 0;
-  margin-bottom: 2rem;
-  box-shadow: 0 0 12px #00ffff inset, 0 0 20px rgba(255, 0, 255, 0.6);
-`
-
-const MarqueeText = styled.div`
-  display: inline-block;
-  white-space: nowrap;
-  animation: ${marquee} 18s linear infinite;
-  font-family: "Press Start 2P", cursive;
-  font-size: 0.9rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: #ffff00;
-  text-shadow: 0 0 8px #ff00ff;
-`
-
-const RetroPanel = styled.section`
   position: relative;
-  background: linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.25));
-  border: 4px double #00ffff;
-  padding: 2.5rem 2rem;
-  text-align: center;
-  box-shadow: 0 0 25px rgba(255, 0, 255, 0.7), inset 0 0 20px rgba(0, 0, 0, 0.6);
-  color: var(--text-color);
-  text-shadow: 0 0 6px rgba(0, 255, 255, 0.9);
+  overflow: hidden;
+  margin-bottom: 2rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgba(216, 255, 0, 0.6);
+  background: rgba(0, 0, 0, 0.3);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 1.3rem) 0,
+    100% 50%,
+    calc(100% - 1.3rem) 100%,
+    0 100%,
+    1.3rem 50%
+  );
 
   &::after {
     content: "";
     position: absolute;
-    inset: 10px;
-    border: 2px dotted rgba(255, 255, 0, 0.5);
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.35),
+      transparent
+    );
+    animation: ${scanner} 4s linear infinite;
+  }
+`
+
+const MarqueeText = styled.div`
+  white-space: nowrap;
+  font-family: "Orbitron", sans-serif;
+  font-size: clamp(0.78rem, 2vw, 0.95rem);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--acid);
+  text-shadow: 0 0 10px rgba(216, 255, 0, 0.55);
+`
+
+const HeroGrid = styled.section`
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
+  gap: 2rem;
+  align-items: stretch;
+
+  @media (max-width: 760px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const GlassPanel = styled.div`
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: linear-gradient(135deg, rgba(255, 61, 242, 0.2), transparent 28%),
+    linear-gradient(315deg, rgba(0, 245, 255, 0.2), transparent 34%),
+    rgba(5, 3, 32, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  clip-path: polygon(
+    0 2rem,
+    2rem 0,
+    100% 0,
+    100% calc(100% - 2rem),
+    calc(100% - 2rem) 100%,
+    0 100%
+  );
+  box-shadow: inset 0 0 35px rgba(255, 255, 255, 0.05),
+    0 24px 55px rgba(0, 0, 0, 0.34);
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0.8rem;
+    border: 1px solid rgba(0, 245, 255, 0.28);
+    clip-path: inherit;
     pointer-events: none;
   }
 `
 
-const RetroHeading = styled.h2`
-  font-family: "Press Start 2P", cursive;
-  font-size: 1.75rem;
-  margin-bottom: 1.5rem;
-  line-height: 1.8rem;
-  text-transform: uppercase;
-  color: #ffff00;
-  text-shadow: 0 0 10px #ff00ff, 0 0 20px rgba(0, 255, 255, 0.8);
-  animation: ${flicker} 4s infinite;
+const HeroHeading = styled.h2`
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-size: clamp(2rem, 5vw, 4.6rem);
+  color: var(--text-color);
+  text-shadow: 0.08em 0.08em 0 var(--pink), -0.04em -0.04em 0 var(--cyan);
 `
 
-const RetroParagraph = styled.p`
-  font-size: 1.5rem;
-  margin: 0 auto 1.5rem;
-  max-width: 32rem;
-  line-height: 1.4;
+const HeroCopy = styled.p`
+  max-width: 42rem;
+  font-size: clamp(1.05rem, 2vw, 1.28rem);
+  color: var(--muted-text);
 `
 
-const RetroList = styled.ul`
+const FeatureList = styled.ul`
+  display: grid;
+  gap: 0.85rem;
   list-style: none;
   padding: 0;
-  margin: 2rem auto;
-  max-width: 32rem;
-  font-size: 1.4rem;
+  margin: 2rem 0;
 
   li {
     position: relative;
-    padding-left: 2.5rem;
-    margin-bottom: 1rem;
+    padding: 0.9rem 1rem 0.9rem 3rem;
+    background: rgba(255, 255, 255, 0.06);
+    border-left: 4px solid var(--cyan);
+    clip-path: polygon(
+      0 0,
+      calc(100% - 1rem) 0,
+      100% 50%,
+      calc(100% - 1rem) 100%,
+      0 100%
+    );
   }
 
   li::before {
-    content: "✶";
+    content: "◆";
     position: absolute;
-    left: 0.75rem;
-    color: #00ffff;
-    text-shadow: 0 0 8px #ff00ff;
+    left: 1rem;
+    color: var(--acid);
+    text-shadow: 0 0 12px var(--acid);
   }
 `
 
 const buttonStyles = css`
-  display: inline-block;
-  padding: 1.1rem 1.75rem;
-  border: 3px solid #ff00ff;
-  border-radius: 8px;
-  background: repeating-linear-gradient(135deg, rgba(255, 0, 255, 0.25) 0, rgba(255, 0, 255, 0.25) 12px, rgba(0, 255, 255, 0.25) 12px, rgba(0, 255, 255, 0.25) 24px);
-  color: #ffff00;
-  text-decoration: none;
-  font-family: "Press Start 2P", cursive;
-  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.2rem;
+  padding: 0.9rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: linear-gradient(
+    135deg,
+    rgba(216, 255, 0, 0.95),
+    rgba(0, 245, 255, 0.9) 48%,
+    rgba(255, 61, 242, 0.95)
+  );
+  color: #12002f;
+  font-family: "Orbitron", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 900;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
-  box-shadow: 0 0 18px rgba(255, 0, 255, 0.8), inset 0 0 12px rgba(0, 255, 255, 0.5);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  letter-spacing: 0.12em;
+  clip-path: polygon(0.8rem 0, 100% 0, calc(100% - 0.8rem) 100%, 0 100%);
+  box-shadow: 0 10px 0 rgba(255, 61, 242, 0.38), 0 20px 30px rgba(0, 0, 0, 0.22);
+  transform: translateY(0);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 
   &:hover,
   &:focus {
-    transform: translateY(-6px) rotate(-1.5deg);
-    box-shadow: 0 0 25px rgba(255, 255, 0, 0.9), inset 0 0 14px rgba(0, 255, 255, 0.8);
-    color: #ffffff;
-  }
-
-  &:active {
-    transform: translateY(2px) scale(0.98);
+    color: #12002f;
+    filter: saturate(1.3) brightness(1.08);
+    transform: translateY(-6px) rotate(-1deg);
+    box-shadow: 0 16px 0 rgba(0, 245, 255, 0.28), 0 30px 42px rgba(0, 0, 0, 0.3);
   }
 `
 
-const RetroLinks = styled.div`
+const LinkGrid = styled.div`
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 1.25rem;
+  gap: 1rem;
 `
 
 const SocialLink = styled.a`
   ${buttonStyles}
 `
 
-const RetroSticker = styled.div`
-  margin-top: 2.5rem;
-  padding: 1rem 1.5rem;
-  border: 3px dashed #00ffff;
-  background: rgba(0, 0, 0, 0.65);
-  display: inline-block;
-  font-size: 1.2rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  box-shadow: 0 0 15px rgba(0, 255, 255, 0.8);
+const SceneCard = styled.aside`
+  position: relative;
+  min-height: 28rem;
+  overflow: hidden;
+  background: radial-gradient(
+      circle at 50% 35%,
+      rgba(216, 255, 0, 0.24),
+      transparent 9rem
+    ),
+    linear-gradient(180deg, rgba(0, 245, 255, 0.15), rgba(255, 61, 242, 0.15)),
+    rgba(0, 0, 0, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 2rem) 0,
+    100% 2rem,
+    100% 100%,
+    2rem 100%,
+    0 calc(100% - 2rem)
+  );
 `
 
-const SparkleRow = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-top: 2rem;
-  font-size: 1.5rem;
-  color: #ffff00;
-  text-shadow: 0 0 12px #ff00ff;
+const PolyShard = styled.span`
+  position: absolute;
+  display: block;
+  width: ${props => props.size};
+  height: ${props => props.size};
+  left: ${props => props.left};
+  top: ${props => props.top};
+  background: ${props => props.gradient};
+  clip-path: ${props => props.shape};
+  filter: drop-shadow(0 18px 20px rgba(0, 0, 0, 0.25));
+  animation: ${hoverShard} ${props => props.speed} ease-in-out infinite;
+  animation-delay: ${props => props.delay};
+`
+
+const SceneLabel = styled.div`
+  position: absolute;
+  left: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  padding: 1rem;
+  background: rgba(3, 0, 26, 0.74);
+  border: 1px solid rgba(216, 255, 0, 0.45);
+  color: var(--acid);
+  font-family: "Orbitron", sans-serif;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 `
 
 const IndexPage = ({ data, location }) => {
@@ -168,44 +244,102 @@ const IndexPage = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO title="Welcome to the Retro Web" />
+      <SEO title="Low-poly Y2K Web Developer" />
       <MarqueeShell>
         <MarqueeText>
-          ✨ Welcome to the official {siteTitle} cyber hub • grab a soda, power up your speakers, and enjoy the ride ✨
+          Low-poly portal initialized • neon mesh loaded • welcome to{" "}
+          {siteTitle}
         </MarqueeText>
       </MarqueeShell>
-      <RetroPanel>
-        <RetroHeading>Hey there, I'm The Dyslexic Developer!</RetroHeading>
-        <RetroParagraph>
-          Plug in your modem and join me on a neon-soaked tour through my corner of the internet. I build playful
-          experiences, tinker with creative code, and share stories about the journey along the way.
-        </RetroParagraph>
-        <RetroList>
-          <li>Dial-up deep dives into code, art, and accessibility.</li>
-          <li>Creative experiments fueled by caffeine and curiosity.</li>
-          <li>A community-minded builder who still loves a good easter egg.</li>
-        </RetroList>
-        <RetroLinks>
-          <SocialLink href="https://twitter.com/TheDyslexicDev" target="_blank" rel="noopener noreferrer">
-            Twitter HQ
-          </SocialLink>
-          <SocialLink href="https://github.com/TheDyslexicDeveloper" target="_blank" rel="noopener noreferrer">
-            GitHub Lab
-          </SocialLink>
-          <SocialLink href="https://instagram.com/thedyslexicdeveloper" target="_blank" rel="noopener noreferrer">
-            Instagram Gallery
-          </SocialLink>
-          <SocialLink href="/about">
-            About Me
-          </SocialLink>
-        </RetroLinks>
-        <SparkleRow>
-          <span>★</span>
-          <span>Beep Boop</span>
-          <span>★</span>
-        </SparkleRow>
-        <RetroSticker>Constructed with love, pixels, and a dash of nostalgia.</RetroSticker>
-      </RetroPanel>
+      <HeroGrid>
+        <GlassPanel>
+          <HeroHeading>
+            Code, streams, and glitches from the future past.
+          </HeroHeading>
+          <HeroCopy>
+            I build playful web experiences with a sharp edge: accessible
+            interfaces, creative tooling, open-source experiments, and the
+            occasional digital easter egg rendered in full Y2K chrome.
+          </HeroCopy>
+          <FeatureList>
+            <li>
+              Low-poly thoughts on JavaScript, React, security, and creative
+              code.
+            </li>
+            <li>
+              Livestream-friendly builds with curiosity, caffeine, and community
+              at the center.
+            </li>
+            <li>
+              Accessibility-minded systems with nostalgic energy and modern
+              craft.
+            </li>
+          </FeatureList>
+          <LinkGrid>
+            <SocialLink
+              href="https://twitter.com/TheDyslexicDev"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Twitter
+            </SocialLink>
+            <SocialLink
+              href="https://github.com/TheDyslexicDeveloper"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </SocialLink>
+            <SocialLink
+              href="https://instagram.com/thedyslexicdeveloper"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Instagram
+            </SocialLink>
+            <SocialLink href="/about">About</SocialLink>
+          </LinkGrid>
+        </GlassPanel>
+        <SceneCard aria-label="Decorative low-poly 3D Y2K scene">
+          <PolyShard
+            size="11rem"
+            left="18%"
+            top="12%"
+            speed="7s"
+            delay="0s"
+            shape="polygon(50% 0, 100% 36%, 80% 100%, 20% 100%, 0 36%)"
+            gradient="linear-gradient(135deg, var(--acid), var(--orange))"
+          />
+          <PolyShard
+            size="8rem"
+            left="54%"
+            top="20%"
+            speed="6s"
+            delay="-2s"
+            shape="polygon(0 0, 100% 18%, 72% 100%, 14% 70%)"
+            gradient="linear-gradient(135deg, var(--cyan), var(--violet))"
+          />
+          <PolyShard
+            size="13rem"
+            left="28%"
+            top="44%"
+            speed="8s"
+            delay="-4s"
+            shape="polygon(50% 0, 100% 50%, 50% 100%, 0 50%)"
+            gradient="linear-gradient(135deg, var(--pink), var(--violet), var(--cyan))"
+          />
+          <PolyShard
+            size="5rem"
+            left="68%"
+            top="62%"
+            speed="5s"
+            delay="-1s"
+            shape="polygon(50% 0, 100% 100%, 0 78%)"
+            gradient="linear-gradient(135deg, var(--acid), var(--cyan))"
+          />
+          <SceneLabel>Polygon dream machine</SceneLabel>
+        </SceneCard>
+      </HeroGrid>
     </Layout>
   )
 }

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -2,39 +2,78 @@ import React from "react"
 import SEO from "../components/seo"
 import Layout from "../components/layout"
 import { graphql } from "gatsby"
-import styled, { css } from 'styled-components';
+import styled from "styled-components"
 
-import projectsData from '../repos.json';
-import shuffle from '../utils/shuffle';
+import projectsData from "../repos.json"
+import shuffle from "../utils/shuffle"
 
 const StyledList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.25rem;
   list-style: none;
   margin: 0;
   padding: 0;
 
   li {
+    position: relative;
     display: flex;
     flex-direction: column;
-    border: 1px solid #F2643D;
-    padding: 20px 10px;
-    border-radius: 10px;
-    margin-bottom: 20px;
-
-    .name {
-      font-size: 1.5em;
-      color: #EB0A44;
-    }
-
-    .description {
-      font-size: 0.8em;
-    }
-
-    .url {
-      font-size: 0.6em;
-      box-shadow: none;
-    }
+    gap: 0.8rem;
+    min-height: 13rem;
+    padding: 1.35rem;
+    background: linear-gradient(
+        135deg,
+        rgba(0, 245, 255, 0.14),
+        rgba(255, 61, 242, 0.16)
+      ),
+      rgba(0, 0, 0, 0.24);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    clip-path: polygon(
+      0 1.2rem,
+      1.2rem 0,
+      100% 0,
+      100% calc(100% - 1.2rem),
+      calc(100% - 1.2rem) 100%,
+      0 100%
+    );
+    box-shadow: 0 14px 0 rgba(255, 61, 242, 0.18),
+      0 28px 42px rgba(0, 0, 0, 0.22);
   }
-`;
+
+  li::before {
+    content: "";
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    width: 2.4rem;
+    height: 2.4rem;
+    background: linear-gradient(135deg, var(--acid), var(--cyan));
+    clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+    opacity: 0.85;
+  }
+
+  .name {
+    max-width: calc(100% - 3rem);
+    font-family: "Orbitron", sans-serif;
+    font-size: 1.1em;
+    color: var(--acid);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .description {
+    color: var(--muted-text);
+    font-size: 0.9em;
+  }
+
+  .url {
+    margin-top: auto;
+    align-self: flex-start;
+    font-size: 0.78em;
+    word-break: break-word;
+  }
+`
 
 const Projects = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
@@ -43,21 +82,19 @@ const Projects = ({ data, location }) => {
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title={data.site.siteMetadata.title} />
-      <h1>
-        Projects
-      </h1>
+      <h1>Projects</h1>
       <StyledList>
-        {
-          projectList.map(project => {
-            return (
-              <li>
-                <span className="name">{project.name}</span>
-                <span className="description">{project.description}</span>
-                <a href={project.url} className="url">{project.url}</a>
-              </li>
-            )
-          })
-        }
+        {projectList.map(project => {
+          return (
+            <li key={project.url}>
+              <span className="name">{project.name}</span>
+              <span className="description">{project.description}</span>
+              <a href={project.url} className="url">
+                {project.url}
+              </a>
+            </li>
+          )
+        })}
       </StyledList>
     </Layout>
   )
@@ -66,11 +103,11 @@ const Projects = ({ data, location }) => {
 export default Projects
 
 export const pageQuery = graphql`
-    query {
-        site {
-            siteMetadata {
-                title
-            }
-        }
+  query {
+    site {
+      siteMetadata {
+        title
+      }
     }
+  }
 `

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,53 +1,180 @@
-@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;900&family=Space+Mono:wght@400;700&display=swap");
 
 :root {
-    --bg-color: #040013;
-    --text-color: #f8f6ff;
+  --bg-color: #07051f;
+  --panel-color: rgba(18, 15, 60, 0.78);
+  --panel-deep: rgba(3, 0, 26, 0.92);
+  --text-color: #f8f4ff;
+  --muted-text: #c9c1ff;
+  --acid: #d8ff00;
+  --cyan: #00f5ff;
+  --pink: #ff3df2;
+  --violet: #8f4dff;
+  --orange: #ff9d00;
+  --edge: rgba(255, 255, 255, 0.2);
 }
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background: var(--bg-color);
 }
 
 body {
-    margin: 0;
-    font-family: 'VT323', 'Courier New', monospace;
-    font-size: 20px;
-    line-height: 1.6;
-    background-color: var(--bg-color);
-    background-image:
-        radial-gradient(#ff00ff 1px, transparent 1px),
-        radial-gradient(#00ffff 1px, transparent 1px),
-        radial-gradient(#ffff00 1px, transparent 1px);
-    background-size: 120px 120px, 160px 160px, 200px 200px;
-    background-position: 0 0, 40px 100px, 80px 60px;
-    color: var(--text-color);
-    text-shadow: 0 0 4px rgba(0, 255, 255, 0.5);
-    min-height: 100vh;
+  margin: 0;
+  font-family: "Space Mono", "Courier New", monospace;
+  font-size: 18px;
+  line-height: 1.7;
+  background-color: var(--bg-color);
+  background-image: linear-gradient(
+      115deg,
+      rgba(255, 61, 242, 0.2),
+      transparent 32%
+    ),
+    linear-gradient(245deg, rgba(0, 245, 255, 0.18), transparent 38%),
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(216, 255, 0, 0.24),
+      transparent 16rem
+    ),
+    radial-gradient(
+      circle at 86% 4%,
+      rgba(255, 157, 0, 0.22),
+      transparent 14rem
+    ),
+    linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: auto, auto, auto, auto, 48px 48px, 48px 48px;
+  color: var(--text-color);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::before {
+  inset: 0;
+  background: linear-gradient(
+      120deg,
+      transparent 0 11%,
+      rgba(255, 255, 255, 0.06) 11% 11.4%,
+      transparent 11.4% 100%
+    ),
+    linear-gradient(
+      55deg,
+      transparent 0 61%,
+      rgba(0, 245, 255, 0.08) 61% 61.4%,
+      transparent 61.4% 100%
+    ),
+    linear-gradient(
+      300deg,
+      transparent 0 74%,
+      rgba(255, 61, 242, 0.1) 74% 74.35%,
+      transparent 74.35% 100%
+    );
+}
+
+body::after {
+  left: 50%;
+  bottom: -36rem;
+  width: 110rem;
+  height: 70rem;
+  transform: translateX(-50%) perspective(900px) rotateX(62deg);
+  transform-origin: center bottom;
+  background-image: linear-gradient(
+      rgba(0, 245, 255, 0.35) 2px,
+      transparent 2px
+    ),
+    linear-gradient(90deg, rgba(255, 61, 242, 0.28) 2px, transparent 2px);
+  background-size: 5rem 5rem;
+  filter: drop-shadow(0 0 18px rgba(0, 245, 255, 0.5));
+  opacity: 0.62;
+}
+
+::selection {
+  background: var(--acid);
+  color: #13002d;
 }
 
 a {
-    color: #00ffff;
-    text-decoration: underline;
-    text-decoration-style: wavy;
-    text-decoration-color: #ff00ff;
-    text-shadow: 0 0 6px rgba(255, 0, 255, 0.8);
+  color: var(--cyan);
+  text-decoration: none;
+  border-bottom: 2px solid rgba(255, 61, 242, 0.75);
+  box-shadow: inset 0 -0.18em 0 rgba(255, 61, 242, 0.25);
+  transition: color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 a:hover,
 a:focus {
-    color: #ffff00;
-    text-decoration-color: #ffff00;
+  color: var(--acid);
+  border-color: var(--acid);
+  box-shadow: inset 0 -0.45em 0 rgba(0, 245, 255, 0.22),
+    0 0 18px rgba(216, 255, 0, 0.35);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: "Orbitron", "Arial Black", sans-serif;
+  letter-spacing: 0.06em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+h1 {
+  color: var(--acid);
+  text-shadow: 0.08em 0.08em 0 var(--pink), -0.04em -0.04em 0 var(--cyan);
+}
+
+h2,
+h3 {
+  color: var(--cyan);
 }
 
 p {
-    margin-bottom: 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 main {
-    min-height: 50vh;
+  min-height: 50vh;
 }
 
 img {
-    image-rendering: pixelated;
+  max-width: 100%;
+}
+
+hr {
+  border: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--cyan),
+    var(--pink),
+    var(--acid),
+    transparent
+  );
+  box-shadow: 0 0 18px rgba(0, 245, 255, 0.55);
+}
+
+code,
+pre {
+  font-family: "Space Mono", "Courier New", monospace;
+}
+
+pre {
+  border: 1px solid rgba(0, 245, 255, 0.45);
+  background: rgba(0, 0, 0, 0.45);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.3),
+    inset 0 0 24px rgba(143, 77, 255, 0.15);
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,10 +1,55 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
+import styled from "styled-components"
 
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm, scale } from "../utils/typography"
+
+const ArticleShell = styled.article`
+  padding: clamp(1.25rem, 3vw, 2.25rem);
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  clip-path: polygon(0 1.4rem, 1.4rem 0, 100% 0, 100% 100%, 0 100%);
+
+  header p {
+    color: var(--acid);
+    font-family: "Orbitron", sans-serif;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  blockquote {
+    margin-left: 0;
+    padding-left: 1.25rem;
+    border-left: 4px solid var(--pink);
+    color: var(--muted-text);
+  }
+`
+
+const PostNav = styled.nav`
+  margin-top: 2rem;
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    list-style: none;
+    padding: 0;
+  }
+
+  li {
+    max-width: 48%;
+  }
+
+  @media (max-width: 640px) {
+    li {
+      max-width: 100%;
+    }
+  }
+`
 
 const BlogPostTemplate = ({ data, pageContext, location }) => {
   const post = data.markdownRemark
@@ -13,11 +58,8 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO
-        title={post.frontmatter.title}
-        description={post.excerpt}
-      />
-      <article>
+      <SEO title={post.frontmatter.title} description={post.excerpt} />
+      <ArticleShell>
         <header>
           <h1
             style={{
@@ -46,18 +88,10 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
         <footer>
           <Bio />
         </footer>
-      </article>
+      </ArticleShell>
 
-      <nav>
-        <ul
-          style={{
-            display: `flex`,
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-            listStyle: `none`,
-            padding: 0,
-          }}
-        >
+      <PostNav>
+        <ul>
           <li>
             {previous && (
               <Link to={previous.fields.slug} rel="prev">
@@ -73,7 +107,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
             )}
           </li>
         </ul>
-      </nav>
+      </PostNav>
     </Layout>
   )
 }


### PR DESCRIPTION
### Motivation
- Refresh the site's visual identity to a cohesive low‑poly 3D / Y2K aesthetic while keeping the content structure intact.  
- Provide reusable, modernized UI surfaces (glass panels, polygon shards, chromatic CTAs) that carry the look across homepage, posts, and auxiliary pages.  
- Improve typographic and color tokens to make future theme adjustments easier and ensure consistent styling.

### Description
- Reworked the global visual system in `src/styles/global.css` with new fonts (`Orbitron`, `Space Mono`), color tokens, perspective backgrounds, grid overlays and updated code/HR styles.  
- Redesigned site shell in `src/components/layout.js` to a glassy clipped container with animated glow and decorative shard, and replaced the footer with a compact `FooterBar`.  
- Rebuilt the title and homepage hero in `src/components/title.js` and `src/pages/index.js` with animated chromatic gradients, 3D transforms, faceted CTAs and decorative `PolyShard` components to simulate low‑poly 3D scenes.  
- Restyled supporting components and pages (`src/components/bio.js`, `src/components/inLineLink.js`, `src/templates/blog-post.js`, `src/pages/projects.js`, `src/pages/about.js`, `src/pages/404.js`) to match the new aesthetic and updated markup/ARIA usage where relevant.

### Testing
- Ran code style checks and formatting with `npx prettier --check` and `npx prettier --write` across modified files, which passed after formatting.  
- Verified repository diffs (`git diff --stat`) and ran `git diff --check` with no blocking issues reported.  
- Attempted to run `npm run build` to validate a production build, but the build was blocked due to the native `sharp` module failing to install / load in this environment (Gatsby could not find `../build/Release/sharp.node`), so full static build verification could not complete.  
- Dependency installation steps were attempted (including using Node v18 via `nvm` and `npm ci`), but `sharp` required native rebuilds that failed in the container; automated lint/format checks remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03176e1db0832abdcf651f7df9d2ab)