### PR TITLE
[codex] Add Fridge to Feat support and privacy pages

### DIFF
--- a/src/components/fridgeToFeatPage.js
+++ b/src/components/fridgeToFeatPage.js
@@ -1,0 +1,94 @@
+import React from "react"
+import { Link } from "gatsby"
+import styled from "styled-components"
+
+import Layout from "./layout"
+import SEO from "./seo"
+
+const AppHeader = styled.header`
+  margin-bottom: 2.5rem;
+  padding: 2rem;
+  border: 3px solid #00ffff;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 140, 0, 0.18),
+    rgba(0, 255, 255, 0.13)
+  );
+  box-shadow: inset 0 0 24px rgba(0, 255, 255, 0.16);
+
+  h1 {
+    margin: 0.75rem 0;
+    color: #ffff00;
+    line-height: 1.15;
+  }
+
+  p {
+    margin: 0;
+    max-width: 38rem;
+  }
+`
+
+const AppName = styled.div`
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.7rem;
+  letter-spacing: 0.13em;
+  color: #00ffff;
+  text-transform: uppercase;
+`
+
+const PageBody = styled.article`
+  max-width: 45rem;
+
+  h2 {
+    margin-top: 2.4rem;
+    color: #ffff00;
+  }
+
+  h3 {
+    margin-top: 1.75rem;
+    color: #00ffff;
+  }
+
+  ul {
+    padding-left: 1.5rem;
+  }
+
+  li {
+    margin-bottom: 0.8rem;
+  }
+`
+
+const LegalNavigation = styled.nav`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px dashed rgba(0, 255, 255, 0.6);
+`
+
+const FridgeToFeatPage = ({
+  location,
+  title,
+  description,
+  intro,
+  children,
+}) => (
+  <Layout location={location} title="Fridge to Feat">
+    <SEO title={`${title} - Fridge to Feat`} description={description} />
+    <AppHeader>
+      <AppName>Fridge to Feat</AppName>
+      <h1>{title}</h1>
+      <p>{intro}</p>
+    </AppHeader>
+    <PageBody>
+      {children}
+      <LegalNavigation aria-label="Fridge to Feat pages">
+        <Link to="/fridge-to-feat/support/">Support</Link>
+        <Link to="/fridge-to-feat/privacy/">Privacy Policy</Link>
+      </LegalNavigation>
+    </PageBody>
+  </Layout>
+)
+
+export default FridgeToFeatPage

--- a/src/pages/fridge-to-feat/privacy.js
+++ b/src/pages/fridge-to-feat/privacy.js
@@ -1,0 +1,105 @@
+import React from "react"
+
+import FridgeToFeatPage from "../../components/fridgeToFeatPage"
+
+const PrivacyPage = ({ location }) => (
+  <FridgeToFeatPage
+    location={location}
+    title="Privacy Policy"
+    description="Privacy Policy for the Fridge to Feat iOS app."
+    intro="This policy explains what Fridge to Feat processes when you turn fridge photos into meal ideas."
+  >
+    <p>
+      <strong>Effective date:</strong> 25 May 2026
+    </p>
+
+    <h2>Overview</h2>
+    <p>
+      Fridge to Feat is an iOS app by Chris Laughlin. The app uses your photos
+      and ingredient selections to generate meal inspiration. It does not sell
+      your personal information or use your app content for advertising.
+    </p>
+
+    <h2>Information Processed</h2>
+    <ul>
+      <li>
+        <strong>Fridge photos:</strong> Photos you capture or select are
+        processed to identify visible ingredients.
+      </li>
+      <li>
+        <strong>Ingredient and meal content:</strong> Detected or manually
+        entered ingredients are processed to generate meal ideas, including
+        cooking steps.
+      </li>
+      <li>
+        <strong>Credit and purchase information:</strong> The app processes an
+        anonymous account identifier, credit balance, and purchase verification
+        information needed to provide purchased credits.
+      </li>
+    </ul>
+
+    <h2>How Information Is Used</h2>
+    <ul>
+      <li>To detect ingredients from the photos you submit.</li>
+      <li>To generate meal ideas at your request.</li>
+      <li>To maintain and sync your credit balance.</li>
+      <li>To verify in-app purchases and provide purchased credits.</li>
+      <li>To diagnose problems when you contact support.</li>
+    </ul>
+
+    <h2>Storage And Sharing</h2>
+    <p>
+      Your saved photos, ingredient history, and generated meals are stored on
+      your device using Apple's local app storage. They are not stored in a
+      Fridge to Feat cloud account.
+    </p>
+    <p>
+      When you ask the app to scan photos or create meal ideas, the required
+      photos or ingredient text are sent to OpenRouter and its selected AI model
+      provider to return the requested result. Do not submit photos containing
+      people or other sensitive information.
+    </p>
+    <p>
+      Fridge to Feat uses Supabase to create an anonymous session and maintain
+      credit balances. Purchase verification information may be sent to Supabase
+      to validate credits purchased through Apple's in-app purchase system.
+      Apple processes payments under its own privacy practices.
+    </p>
+
+    <h2>Your Choices</h2>
+    <ul>
+      <li>
+        Camera or photo library access only occurs when you choose to capture or
+        select a photo, subject to iOS permissions.
+      </li>
+      <li>
+        You can avoid photo processing by not using the fridge scanning feature.
+      </li>
+      <li>
+        Removing the app deletes content stored locally by the app from your
+        device. Contact support with questions about credit account data.
+      </li>
+    </ul>
+
+    <h2>Children</h2>
+    <p>
+      Fridge to Feat is not directed to children under 13 and does not knowingly
+      collect personal information from children.
+    </p>
+
+    <h2>Policy Updates</h2>
+    <p>
+      This policy may change as the app develops. Updates will be published on
+      this page with a revised effective date.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      For privacy questions or support requests, contact Chris Laughlin through
+      the developer's{" "}
+      <a href="https://github.com/chrislaughlin">GitHub profile</a>.
+    </p>
+  </FridgeToFeatPage>
+)
+
+export default PrivacyPage

--- a/src/pages/fridge-to-feat/support.js
+++ b/src/pages/fridge-to-feat/support.js
@@ -1,0 +1,52 @@
+import React from "react"
+
+import FridgeToFeatPage from "../../components/fridgeToFeatPage"
+
+const SupportPage = ({ location }) => (
+  <FridgeToFeatPage
+    location={location}
+    title="Support"
+    description="Support for Fridge to Feat, the iOS app that turns fridge ingredients into meal ideas."
+    intro="Need a hand with a scan, meal ideas, or credits? Here is how to get help with Fridge to Feat."
+  >
+    <h2>How Fridge to Feat Works</h2>
+    <p>
+      Fridge to Feat lets you take or choose photos of your fridge, check the
+      ingredients it identifies, and use credits to generate three meal ideas
+      from what you already have.
+    </p>
+
+    <h2>Common Questions</h2>
+    <h3>Why did the app miss an ingredient?</h3>
+    <p>
+      Lighting, labels, containers, and hidden items can affect detection. You
+      can add missing ingredients or remove incorrect ones before creating meal
+      ideas.
+    </p>
+
+    <h3>Why can I not generate meal ideas?</h3>
+    <p>
+      Confirm that your ingredient list contains at least one item and that you
+      have enough credits. An internet connection is required for ingredient
+      detection, meal generation, and purchase verification.
+    </p>
+
+    <h3>I purchased credits but do not see them.</h3>
+    <p>
+      Reopen the app while connected to the internet so it can sync your credit
+      balance. If the problem continues, include the approximate purchase date
+      when contacting support. Do not send payment details or photos of your
+      fridge.
+    </p>
+
+    <h2>Contact Support</h2>
+    <p>
+      For support or privacy questions, contact Chris Laughlin through the
+      developer's <a href="https://github.com/chrislaughlin">GitHub profile</a>.
+      Please include the app name, your iOS version, and a short description of
+      the issue.
+    </p>
+  </FridgeToFeatPage>
+)
+
+export default SupportPage


### PR DESCRIPTION
## What changed

- Added a public Fridge to Feat Support page at `/fridge-to-feat/support/` with feature guidance, purchase/credit troubleshooting, and a developer contact route.
- Added a public Privacy Policy page at `/fridge-to-feat/privacy/` describing photo and ingredient processing, OpenRouter AI requests, local storage, Supabase anonymous credit sync, and Apple in-app purchases.
- Added a shared styled page wrapper and cross-navigation so both pages match the site and remain easy to reach from each other.

## Why

App Store Connect requires a public Support URL and a publicly accessible Privacy Policy URL for the Fridge to Feat listing.

After deployment, the listing URLs will be:

- Support URL: `https://www.thedyslexicdeveloper.com/fridge-to-feat/support/`
- Privacy Policy URL: `https://www.thedyslexicdeveloper.com/fridge-to-feat/privacy/`

## Validation

- Ran Prettier on the three new source files.
- Ran `git diff --cached --check` successfully.
- Attempted `npm run build`; it is blocked during existing plugin loading because this Gatsby 2 project pins `sharp@0.25.2`, whose native binary cannot be built in the available Node 24/libvips environment (`vips/vips8` not found).